### PR TITLE
Add Claude 3.5 Sonnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,16 +77,19 @@ Other properties are duplicated from the original input.
 
 ## Configuration
 ### LLM backends
-VexLLM is tested with OpenAI GPT-3.5 Turbo.
+VexLLM is tested with OpenAI GPT-3.5 Turbo and Anthropic Claude 3.5 Sonnet.
 
 The following env vars are recognized:
-- `OPENAI_API_KEY` (necessary)
-- `OPENAI_MODEL`
-- `OPENAI_BASE_URL`
-- `OPENAI_API_BASE`
-- `OPENAI_ORGANIZATION`
+- OpenAI
+  - `OPENAI_API_KEY` (necessary)
+  - `OPENAI_MODEL`
+  - `OPENAI_BASE_URL`
+  - `OPENAI_API_BASE`
+  - `OPENAI_ORGANIZATION`
+- Anthropic
+  - `ANTHROPIC_API_KEY` (necessary)
 
-VexLLM may also work with Google AI, Anthropic, and Ollama, but these backends are not tested.
+VexLLM may also work with Google AI, and Ollama, but these backends are not tested.
 See [`pkg/llm/...`](./pkg/llm/).
 
 ## Command reference


### PR DESCRIPTION
Claude 3.5 Sonnet also works in my environment after https://github.com/AkihiroSuda/vexllm/pull/3

I didn't find any envs other than ANTHROPIC_API_KEY.
https://github.com/tmc/langchaingo/blob/4fc43db4fbfb7f9714c7172562fa5b3c5f7583a5/llms/anthropic/anthropicllm_option.go#L8