### PR TITLE
Enable actions/attest-build-provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    # The maximum access is "read" for PRs from public forked repos
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,6 +47,9 @@ jobs:
 
           The sha256sum of the SHA256SUMS file itself is \`${shasha}\` .
           EOF
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: _artifacts/*
       - name: "Create release"
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         env:


### PR DESCRIPTION
https://github.com/actions/attest-build-provenance

https://github.blog/changelog/2024-06-25-artifact-attestations-is-generally-available/