### PR TITLE
feat: support ollama via OLLAMA_MODEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ The following env vars are recognized:
   - `OPENAI_ORGANIZATION`
 - Anthropic
   - `ANTHROPIC_API_KEY` (necessary)
+- Ollama
+  - `OLLAMA_MODEL`, e.g., `qwen3:8b`, `gemma3:4b`
 
 VexLLM may also work with Google AI, and Ollama, but these backends are not tested.
 See [`pkg/llm/...`](./pkg/llm/).

--- a/pkg/llm/llmfactory/llmfactory.go
+++ b/pkg/llm/llmfactory/llmfactory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/AkihiroSuda/vexllm/pkg/llm"
 	"github.com/tmc/langchaingo/llms"
@@ -26,7 +27,9 @@ func New(ctx context.Context, name string) (llms.Model, error) {
 	case llm.OpenAI:
 		return openai.New()
 	case llm.Ollama:
-		return ollama.New()
+		var ollamaModel string
+		ollamaModel = os.Getenv("OLLAMA_MODEL")
+		return ollama.New(ollama.WithModel(ollamaModel))
 	case llm.Anthropic:
 		return anthropic.New()
 	case llm.GoogleAI:


### PR DESCRIPTION
When using the `ollama` backend, the model name is required.  
However, the upstream `langchain` does not provide a way to fetch the variable from the environment.  
As a result, it will always return the following error when attempting to use the `ollama` backend:  
`time=2025-06-01T05:52:54.135+08:00 level=ERROR msg=Error error="model is required"`  

In this PR, I have added a method to receive the model name from the environment via `OLLAMA_MODEL`.  
After setting this variable, vexllm works with the `ollama` backend.

Maybe fixes #42 