### PR TITLE
feat: support GoogleAI with GOOGLE_API_KEY and GOOGLE_MODEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ The following env vars are recognized:
   - `ANTHROPIC_API_KEY` (necessary)
 - Ollama
   - `OLLAMA_MODEL`, e.g., `qwen3:8b`, `gemma3:4b`
+- Google AI
+  - `GOOGLE_API_KEY` (necessary)
+  - `GOOGLE_MODEL` (necessary), e.g., `gemini-2.0-flash` (recommanded)
 
 VexLLM may also work with Anthropic, Google AI, and others, but these backends are not tested.
 See [`pkg/llm/...`](./pkg/llm/).

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -23,9 +23,11 @@ func IsRateLimit(err error) bool {
 	errS := err.Error()
 	// OpenAI (2024-07-11):
 	// error="API returned unexpected status code: 429: Rate limit reached for gpt-3.5-turbo in organization org-XXXXXXXX on tokens per min (TPM): Limit 60000, Used 40635, Requested 23224. Please try again in 3.858s. Visit https://platform.openai.com/account/rate-limits to learn more."
+	// Google AI (2025-06-08):
+	// error="error in stream mode: googleapi: Error 429:"
 	//
 	// TODO: add more checks (in the langchaingo upstream?)
-	return strings.Contains(errS, "status code: 429")
+	return strings.Contains(errS, "status code: 429") || strings.Contains(errS, "Error 429:")
 }
 
 func IsTooManyTokens(err error) bool {

--- a/pkg/llm/llmfactory/llmfactory.go
+++ b/pkg/llm/llmfactory/llmfactory.go
@@ -33,7 +33,9 @@ func New(ctx context.Context, name string) (llms.Model, error) {
 	case llm.Anthropic:
 		return anthropic.New()
 	case llm.GoogleAI:
-		return googleai.New(ctx)
+		var defaultModel string
+		defaultModel = os.Getenv("GOOGLE_MODEL")
+		return googleai.New(ctx, googleai.WithDefaultModel(defaultModel))
 	default:
 		return nil, fmt.Errorf("unknown LLM %q, make sure to use one of %v", name, llm.Names)
 	}


### PR DESCRIPTION
Langchain will retrieve `GOOGLE_API_KEY` from the environment if `googleai.WithAPIKey()` is not provided.

The default model used by Langchain is `gemini-pro`, which does not work on the free plan and returns a `404` error. Therefore, I retrieve the model name from `GOOGLE_MODEL`.

Additionally, the free plan of Google AI may encounter rate limiting issues, resulting in an `Error 429:`. We should handle this case as well.

An example when encountering the rate limiting issue:

```txt
[...]
	"CVE-2025-37995": {
		"confidence": 0.9,
		"reason": "This is a kernel vulnerability related to the module subsystem. Since the artifact is a container image and not a kernel, this vulnerability is negligible."
	}
}time=2025-06-08T04:04:12.565+08:00 level=INFO msg="Detected rate limit. Sleeping." interval=10s error="error in stream mode: googleapi: Error 429:"
[...]
```