### PR TITLE
CI: temporarily disable release check for PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ on:
       - 'master'
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - 'master'
 jobs:
   release:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Not likely compromised so far, but temporarily disable the check during investigation.